### PR TITLE
Unsanitized JavaScript code injection possible in gatsby-plugin-mdx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8213,8 +8213,8 @@
       }
     },
     "gatsby-plugin-mdx": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.2.12.tgz",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.14.1.tgz",
       "integrity": "sha512-zoVXdn3WD1aAmrQikQAzLRrKYjT3h9cTr1Qh3tsHB6tTwjlf+Nbo3liITPVvJ9GwVfgcbL69/uuQ0q/BjU2kJQ==",
       "requires": {
         "@babel/core": "^7.9.6",


### PR DESCRIPTION
The gatsby-plugin-mdx plugin prior to versions 3.15.2 and 2.14.1 passes input through to the gray-matter npm package, which is vulnerable to JavaScript injection in its default configuration, unless input is sanitized. The vulnerability is present when passing input in both webpack (MDX files in src/pages or MDX file imported as component in frontend / React code) and data mode (querying MDX nodes via GraphQL). Injected JavaScript executes in the context of the build server.

To exploit this vulnerability untrusted/unsanitized input would need to be sourced or added into an MDX file. The following MDX payload demonstrates a vulnerable configuration:
```
---js
((require("child_process")).execSync("id >> /tmp/rce"))
--- 
```

**CVE-2022-25863**
``CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N``